### PR TITLE
Fix response for JsonParser, if $rawBody is empty string.

### DIFF
--- a/src/Parser/JsonParser.php
+++ b/src/Parser/JsonParser.php
@@ -25,6 +25,10 @@ final class JsonParser implements ParserInterface
 
     public function parse(string $rawBody)
     {
+        if ($rawBody === '') {
+            return null;
+        }
+
         try {
             $result = \json_decode($rawBody, $this->convertToAssociativeArray, $this->depth, $this->options);
             if (\is_array($result) || \is_object($result)) {

--- a/tests/Parser/JsonParserTest.php
+++ b/tests/Parser/JsonParserTest.php
@@ -54,4 +54,12 @@ final class JsonParserTest extends TestCase
 
         $this->assertSame(['test' => 'value', 'invalid' => ''], $parsed);
     }
+
+    public function testEmptyBody(): void
+    {
+        $parser = new JsonParser();
+        $parsed = $parser->parse('');
+
+        $this->assertNull($parsed);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
